### PR TITLE
fix: remove gpg from actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,17 +10,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v3
-        with:
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
-          git-user-signingkey: true
-          git-tag-gpgsign: true
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - name: Create GitHub release
         uses: Roang-zero1/github-create-release-action@v2.1.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 release:
-	@bash -c "$$(curl -s https://raw.githubusercontent.com/escaletech/releaser/master/tag-and-push.sh)"
+	npx github:escaletech/releaser --gpg-sign


### PR DESCRIPTION
It's done on releaser locally now. We don't need those.