### PR TITLE
feat!: split volumes in named_volumes & host_paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,14 +124,15 @@ module "proxy" {
 | docker\_networks | List of custom networks to create | <pre>list(object({<br>    name = string<br>    ipam_config = object({<br>      aux_address = map(string)<br>      gateway     = string<br>      subnet      = string<br>    })<br>  }))</pre> | `null` | no |
 | environment | Add environment variables | `list(string)` | `null` | no |
 | healthcheck | Test to check if container is healthy | <pre>object({<br>    interval     = string<br>    retries      = number<br>    start_period = string<br>    test         = list(string)<br>    timeout      = string<br>  })</pre> | `null` | no |
+| host\_paths | Mount host paths | <pre>list(object({<br>    host_path      = string<br>    container_path = string<br>    read_only      = bool<br>  }))</pre> | `null` | no |
 | image | Specify the image to start the container from. Can either be a repository/tag or a partial image ID | `string` | n/a | yes |
 | name | Custom container name | `string` | `null` | no |
+| named\_volumes | Mount named volumes | <pre>list(object({<br>    volume_name    = string<br>    container_path = string<br>    read_only      = bool<br>    create         = bool<br>  }))</pre> | `null` | no |
 | network\_mode | Specify a custom network mode | `string` | `null` | no |
 | networks\_advanced | Advanced network options for the container | <pre>object({<br>    name         = string<br>    aliases      = list(string)<br>    ipv4_address = string<br>    ipv6_address = string<br>  })</pre> | `null` | no |
 | ports | Expose ports | <pre>list(object({<br>    internal = number<br>    external = number<br>    protocol = string<br>  }))</pre> | `null` | no |
 | privileged | Give extended privileges to this container | `bool` | `false` | no |
 | restart\_policy | Restart policy. Default: no | `string` | `"no"` | no |
-| volumes | Mount host paths or named volumes, specified as sub-options to a service | <pre>list(object({<br>    volume_name    = string<br>    container_path = string<br>    host_path      = string<br>    read_only      = bool<br>    create         = bool<br>  }))</pre> | `null` | no |
 | working\_dir | Working directory inside the container | `string` | `null` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -14,8 +14,8 @@ resource "docker_image" "default" {
 }
 
 resource "docker_volume" "default" {
-  count = var.volumes != null ? length(matchkeys(var.volumes.*.volume_name, var.volumes.*.create, [true])) : 0
-  name  = var.volumes[count.index].volume_name
+  count = var.named_volumes != null ? length(matchkeys(var.named_volumes.*.volume_name, var.named_volumes.*.create, [true])) : 0
+  name  = var.named_volumes[count.index].volume_name
 }
 
 resource "docker_network" "default" {
@@ -51,9 +51,17 @@ resource "docker_container" "default" {
   }
 
   dynamic "volumes" {
-    for_each = var.volumes == null ? [] : var.volumes
+    for_each = var.named_volumes == null ? [] : var.named_volumes
     content {
       volume_name    = volumes.value.volume_name
+      container_path = volumes.value.container_path
+      read_only      = volumes.value.read_only
+    }
+  }
+
+  dynamic "volumes" {
+    for_each = var.host_paths == null ? [] : var.host_paths
+    content {
       host_path      = volumes.value.host_path
       container_path = volumes.value.container_path
       read_only      = volumes.value.read_only

--- a/variables.tf
+++ b/variables.tf
@@ -46,14 +46,22 @@ variable "ports" {
   }))
   default = null
 }
-variable "volumes" {
-  description = "Mount host paths or named volumes, specified as sub-options to a service"
+variable "named_volumes" {
+  description = "Mount named volumes"
   type = list(object({
     volume_name    = string
     container_path = string
-    host_path      = string
     read_only      = bool
     create         = bool
+  }))
+  default = null
+}
+variable "host_paths" {
+  description = "Mount host paths"
+  type = list(object({
+    host_path      = string
+    container_path = string
+    read_only      = bool
   }))
   default = null
 }


### PR DESCRIPTION
BREAKING CHANGE: Volumes need to be refactorized:

```hcl
named_volumes = [
  {
    volume_name    = string
    container_path = string
    read_only      = bool
    create         = bool
  }
]

host_paths = [
  {
    host_path      = string
    container_path = string
    read_only      = bool
  }
]
```