### PR TITLE
feat: add from_containers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,32 @@ module "proxy" {
     aliases = null
   }
 }
+
+module "letsencrypt-companion" {
+  source = "alinefr/module/docker"
+  version = "<add latest version>"
+
+  image = "jrcs/letsencrypt-nginx-proxy-companion"
+  container_name = "letsencrypt-companion"
+  restart_policy = "always"
+  volumes_from_containers = [
+    {
+      container_name = "proxy"
+    }
+  ]
+    {
+      container_path = "/var/run/docker.sock"
+      host_path = "/var/run/docker.sock"
+      read_only = true
+    }
+  ]
+  networks_advanced = {
+    name = "proxy-tier"
+    ipv4_address = "10.0.20.101"
+    ipv6_address = null
+    aliases = null
+  }
+}
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -128,6 +154,7 @@ module "proxy" {
 | ports | Expose ports | <pre>list(object({<br>    internal = number<br>    external = number<br>    protocol = string<br>  }))</pre> | `null` | no |
 | privileged | Give extended privileges to this container | `bool` | `false` | no |
 | restart\_policy | Restart policy. Default: no | `string` | `"no"` | no |
+| volumes\_from\_containers | Mount volumes from another container | <pre>list(object({<br>    container_name = string<br>  }))</pre> | `null` | no |
 | working\_dir | Working directory inside the container | `string` | `null` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,13 @@ resource "docker_container" "default" {
     }
   }
 
+  dynamic "volumes" {
+    for_each = var.volumes_from_containers == null ? [] : var.volumes_from_containers
+    content {
+      from_container = volumes.value.container_name
+    }
+  }
+
   dynamic "devices" {
     for_each = var.devices == null ? [] : var.devices
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -70,6 +70,13 @@ variable "host_paths" {
   }))
   default = null
 }
+variable "volumes_from_containers" {
+  description = "Mount volumes from another container"
+  type = list(object({
+    container_name = string
+  }))
+  default = null
+}
 variable "devices" {
   description = "Device mappings"
   type = list(object({


### PR DESCRIPTION
Adds a new optional block `from_containers`.
It's the equivalent of `--volumes-from` docker option.