### PR TITLE
feat!: use map of objects for dynamic map blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It should replace other means of docker maintenance like docker-compose.
 
 There are several advantages of maintaining docker on terraform.
 
-* Infrastructure as code. You don't need to manually ssh into servers
+* Infrastructure as code.
 * CI/CD. Many CI tools offers some way to automate terraform execution.
 * Remote execution. You don't need to manually ssh into servers.
 
@@ -27,16 +27,15 @@ module "proxy" {
   image = "masnagam/nginx-proxy:latest"
   container_name = "proxy"
   restart_policy = "always"
-  docker_networks = [
-    {
-      name = "proxy-tier"
+  docker_networks = {
+    "proxy-tier" = {
       ipam_config = {
         aux_address = {}
         gateway = "10.0.20.1"
         subnet = "10.0.20.0/24"
       }
     }
-  ]
+  }
   ports = [
     {
       internal = 80
@@ -49,37 +48,32 @@ module "proxy" {
       protocol = "tcp"
     }
   ]
-  named_volumes = [
-    {
-      volume_name = "nginx_confs"
+  named_volumes = {
+    "nginx_confs" = {
       container_path = "/etc/nginx/conf.d"
       read_only = false
       create = true
     },
-    {
-      volume_name = "nginx_html"
+    "nginx_html" = {
       container_path = "/var/www/html"
       read_only = false
       create = true
     }
-  ]
-  host_paths = [
-    {
+  }
+  host_paths = {
+    "/media/letsencrypt/etc/letsencrypt/live" = {
       container_path = "/etc/nginx/certs"
-      host_path = "/media/letsencrypt/etc/letsencrypt/live"
       read_only = false
     },
-    {
+    "/media/letsencrypt/etc/letsencrypt/archive" = {
       container_path = "/etc/nginx/archive"
-      host_path = "/media/letsencrypt/etc/letsencrypt/archive"
       read_only = false
     },
-    {
+    "/var/run/docker.sock" = {
       container_path = "/tmp/docker.sock"
-      host_path = "/var/run/docker.sock"
       read_only = true
     }
-  ]
+  }
   capabilities = {
     add = ["NET_ADMIN"]
     drop = []
@@ -100,17 +94,14 @@ module "letsencrypt-companion" {
   container_name = "letsencrypt-companion"
   restart_policy = "always"
   volumes_from_containers = [
-    {
-      container_name = "proxy"
-    }
+      "proxy"
   ]
-  host_paths = [
-    {
+  host_paths = {
+    "/var/run/docker.sock" = {
       container_path = "/var/run/docker.sock"
-      host_path = "/var/run/docker.sock"
       read_only = true
     }
-  ]
+  }
   networks_advanced = {
     name = "proxy-tier"
     ipv4_address = "10.0.20.101"
@@ -141,21 +132,21 @@ module "letsencrypt-companion" {
 | capabilities | Add or drop container capabilities | <pre>object({<br>    add  = list(string)<br>    drop = list(string)<br>  })</pre> | `null` | no |
 | command | Override the default command | `list(string)` | `null` | no |
 | container\_name | Custom container name | `string` | `null` | no |
-| devices | Device mappings | <pre>list(object({<br>    host_path      = string<br>    container_path = string<br>    permissions    = string<br>  }))</pre> | `null` | no |
+| devices | Device mappings | <pre>map(object({<br>    container_path = string<br>    permissions    = string<br>  }))</pre> | `{}` | no |
 | dns | Set custom dns servers for the container | `list(string)` | `null` | no |
-| docker\_networks | List of custom networks to create | <pre>list(object({<br>    name = string<br>    ipam_config = object({<br>      aux_address = map(string)<br>      gateway     = string<br>      subnet      = string<br>    })<br>  }))</pre> | `null` | no |
+| docker\_networks | List of custom networks to create | <pre>map(object({<br>    ipam_config = object({<br>      aux_address = map(string)<br>      gateway     = string<br>      subnet      = string<br>    })<br>  }))</pre> | `{}` | no |
 | environment | Add environment variables | `list(string)` | `null` | no |
 | healthcheck | Test to check if container is healthy | <pre>object({<br>    interval     = string<br>    retries      = number<br>    start_period = string<br>    test         = list(string)<br>    timeout      = string<br>  })</pre> | `null` | no |
-| host\_paths | Mount host paths | <pre>list(object({<br>    host_path      = string<br>    container_path = string<br>    read_only      = bool<br>  }))</pre> | `null` | no |
+| host\_paths | Mount host paths | <pre>map(object({<br>    container_path = string<br>    read_only      = bool<br>  }))</pre> | `{}` | no |
 | hostname | Set docker hostname | `string` | `null` | no |
 | image | Specify the image to start the container from. Can either be a repository/tag or a partial image ID | `string` | n/a | yes |
-| named\_volumes | Mount named volumes | <pre>list(object({<br>    volume_name    = string<br>    container_path = string<br>    read_only      = bool<br>    create         = bool<br>  }))</pre> | `null` | no |
+| named\_volumes | Mount named volumes | <pre>map(object({<br>    container_path = string<br>    read_only      = bool<br>    create         = bool<br>  }))</pre> | `{}` | no |
 | network\_mode | Specify a custom network mode | `string` | `null` | no |
 | networks\_advanced | Advanced network options for the container | <pre>object({<br>    name         = string<br>    aliases      = list(string)<br>    ipv4_address = string<br>    ipv6_address = string<br>  })</pre> | `null` | no |
 | ports | Expose ports | <pre>list(object({<br>    internal = number<br>    external = number<br>    protocol = string<br>  }))</pre> | `null` | no |
 | privileged | Give extended privileges to this container | `bool` | `false` | no |
 | restart\_policy | Restart policy. Default: no | `string` | `"no"` | no |
-| volumes\_from\_containers | Mount volumes from another container | <pre>list(object({<br>    container_name = string<br>  }))</pre> | `null` | no |
+| volumes\_from\_containers | Mount volumes from another container | `list` | `null` | no |
 | working\_dir | Working directory inside the container | `string` | `null` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -14,18 +14,18 @@ resource "docker_image" "default" {
 }
 
 resource "docker_volume" "default" {
-  count = var.named_volumes != null ? length(matchkeys(var.named_volumes.*.volume_name, var.named_volumes.*.create, [true])) : 0
-  name  = var.named_volumes[count.index].volume_name
+  for_each = var.named_volumes
+  name     = each.key
 }
 
 resource "docker_network" "default" {
-  count = var.docker_networks != null ? length(var.docker_networks) : 0
-  name  = var.docker_networks[count.index].name
+  for_each = var.docker_networks
+  name     = each.key
 
   ipam_config {
-    aux_address = var.docker_networks[count.index].ipam_config.aux_address
-    gateway     = var.docker_networks[count.index].ipam_config.gateway
-    subnet      = var.docker_networks[count.index].ipam_config.subnet
+    aux_address = each.value.ipam_config.aux_address
+    gateway     = each.value.ipam_config.gateway
+    subnet      = each.value.ipam_config.subnet
   }
 }
 
@@ -52,18 +52,18 @@ resource "docker_container" "default" {
   }
 
   dynamic "volumes" {
-    for_each = var.named_volumes == null ? [] : var.named_volumes
+    for_each = var.named_volumes
     content {
-      volume_name    = volumes.value.volume_name
+      volume_name    = volumes.key
       container_path = volumes.value.container_path
       read_only      = volumes.value.read_only
     }
   }
 
   dynamic "volumes" {
-    for_each = var.host_paths == null ? [] : var.host_paths
+    for_each = var.host_paths
     content {
-      host_path      = volumes.value.host_path
+      host_path      = volumes.key
       container_path = volumes.value.container_path
       read_only      = volumes.value.read_only
     }
@@ -72,14 +72,14 @@ resource "docker_container" "default" {
   dynamic "volumes" {
     for_each = var.volumes_from_containers == null ? [] : var.volumes_from_containers
     content {
-      from_container = volumes.value.container_name
+      from_container = volumes.value
     }
   }
 
   dynamic "devices" {
-    for_each = var.devices == null ? [] : var.devices
+    for_each = var.devices
     content {
-      host_path      = devices.value.host_path
+      host_path      = devices.key
       container_path = devices.value.container_path
       permissions    = devices.value.permissions
     }

--- a/variables.tf
+++ b/variables.tf
@@ -53,38 +53,33 @@ variable "ports" {
 }
 variable "named_volumes" {
   description = "Mount named volumes"
-  type = list(object({
-    volume_name    = string
+  type = map(object({
     container_path = string
     read_only      = bool
     create         = bool
   }))
-  default = null
+  default = {}
 }
 variable "host_paths" {
   description = "Mount host paths"
-  type = list(object({
-    host_path      = string
+  type = map(object({
     container_path = string
     read_only      = bool
   }))
-  default = null
+  default = {}
 }
 variable "volumes_from_containers" {
   description = "Mount volumes from another container"
-  type = list(object({
-    container_name = string
-  }))
-  default = null
+  type        = list
+  default     = null
 }
 variable "devices" {
   description = "Device mappings"
-  type = list(object({
-    host_path      = string
+  type = map(object({
     container_path = string
     permissions    = string
   }))
-  default = null
+  default = {}
 }
 variable "capabilities" {
   description = "Add or drop container capabilities"
@@ -122,13 +117,12 @@ variable "environment" {
 }
 variable "docker_networks" {
   description = "List of custom networks to create"
-  type = list(object({
-    name = string
+  type = map(object({
     ipam_config = object({
       aux_address = map(string)
       gateway     = string
       subnet      = string
     })
   }))
-  default = null
+  default = {}
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     docker = {
-      source  = "terraform-providers/docker"
+      source  = "kreuzwerker/docker"
       version = "~> 2.7"
     }
   }


### PR DESCRIPTION
Instead of using a list of objects, we use now a map of objects.
This would make our declared volumes in our module using a key instead
of a index.

The problem with the key is that it is order dependent. So if the
volumes order is switched in our container module, it makes our volumes
to be deleted & recreated. By referencing it on a key string the order
should not matter.

Fixes #44

BREAKING CHANGE: syntax for volume declaration has changed.

Before:
```
named_volumes = [
  {
    container_name = "nginx_config"
    container_path = "/etc/nginx"
    read_only      = false
    create         = true
  }
]
host_paths = [
  {
    host_path      = "/media/local"
    container_path = "/mnt"
    read_only      = true
  }
]
volumes_from_containers = [
  {
    container_name = "proxy"
  }
]
devices = [
  {
    host_path      = "/dev/vcs"
    container_path = "/dev/vcs"
    permissions    = "rwm"
  }
]
docker_networks = [
  {
    name = "proxy-tier"
    ipam_config = {
      aux_address = {}
      gateway     = "10.0.30.1"
      subnet      = "10.0.30.0/24"
    }
  }
]
```

Now:
```
named_volumes = {
  "nginx_config" = {
    container_path = "/etc/nginx"
    read_only      = false
    create         = true
  }
}
host_paths = {
  "/media/local" = {
    container_path = "/mnt"
    read_only      = true
  }
}
volumes_from_containers = [
  "proxy"
]
devices = {
  "/dev/vcs" = {
    container_path = "/dev/vcs"
    permissions    = "rwm"
  }
}
docker_networks = {
  "proxy-tier" = {
    ipam_config = {
      aux_address = {}
      gateway     = "10.0.30.1"
      subnet      = "10.0.30.1/24"
    }
  }
}
```