### PR TITLE
feat: use map for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ No modules.
 | <a name="input_devices"></a> [devices](#input\_devices) | Device mappings | <pre>map(object({<br>    container_path = string<br>    permissions    = string<br>  }))</pre> | `{}` | no |
 | <a name="input_dns"></a> [dns](#input\_dns) | Set custom dns servers for the container | `list(string)` | `null` | no |
 | <a name="input_docker_networks"></a> [docker\_networks](#input\_docker\_networks) | List of custom networks to create | <pre>map(object({<br>    ipam_config = object({<br>      aux_address = map(string)<br>      gateway     = string<br>      subnet      = string<br>    })<br>  }))</pre> | `{}` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | Add environment variables | `list(string)` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Add environment variables | `map(string)` | `null` | no |
 | <a name="input_healthcheck"></a> [healthcheck](#input\_healthcheck) | Test to check if container is healthy | <pre>object({<br>    interval     = string<br>    retries      = number<br>    start_period = string<br>    test         = list(string)<br>    timeout      = string<br>  })</pre> | `null` | no |
 | <a name="input_host_paths"></a> [host\_paths](#input\_host\_paths) | Mount host paths | <pre>map(object({<br>    container_path = string<br>    read_only      = bool<br>  }))</pre> | `{}` | no |
 | <a name="input_hostname"></a> [hostname](#input\_hostname) | Set docker hostname | `string` | `null` | no |
@@ -168,5 +168,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_devices"></a> [devices](#output\_devices) | n/a |
+| <a name="output_environment"></a> [environment](#output\_environment) | n/a |
 | <a name="output_volumes"></a> [volumes](#output\_volumes) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -5,27 +5,38 @@ No requirements.
 
 ## Providers
 
-No provider.
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_docker"></a> [docker](#module\_docker) | ../.. | n/a |
+
+## Resources
+
+No resources.
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| container\_name | n/a | `string` | n/a | yes |
-| devices | n/a | `map` | `{}` | no |
-| gateway | n/a | `string` | n/a | yes |
-| host\_paths | n/a | `map` | `{}` | no |
-| ipv4\_address | n/a | `string` | n/a | yes |
-| named\_volumes | n/a | `map` | `{}` | no |
-| network\_name | n/a | `string` | n/a | yes |
-| ports | n/a | `list` | `null` | no |
-| subnet | n/a | `string` | n/a | yes |
+| <a name="input_container_name"></a> [container\_name](#input\_container\_name) | n/a | `string` | n/a | yes |
+| <a name="input_devices"></a> [devices](#input\_devices) | n/a | `map(any)` | `{}` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | n/a | `map(string)` | `null` | no |
+| <a name="input_gateway"></a> [gateway](#input\_gateway) | n/a | `string` | n/a | yes |
+| <a name="input_host_paths"></a> [host\_paths](#input\_host\_paths) | n/a | `map(any)` | `{}` | no |
+| <a name="input_ipv4_address"></a> [ipv4\_address](#input\_ipv4\_address) | n/a | `string` | n/a | yes |
+| <a name="input_named_volumes"></a> [named\_volumes](#input\_named\_volumes) | n/a | `map(any)` | `{}` | no |
+| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | n/a | `string` | n/a | yes |
+| <a name="input_ports"></a> [ports](#input\_ports) | n/a | `list(any)` | `null` | no |
+| <a name="input_subnet"></a> [subnet](#input\_subnet) | n/a | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| devices | n/a |
-| volumes | n/a |
-
+| <a name="output_devices"></a> [devices](#output\_devices) | n/a |
+| <a name="output_environment"></a> [environment](#output\_environment) | n/a |
+| <a name="output_volumes"></a> [volumes](#output\_volumes) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -4,6 +4,7 @@ module "docker" {
   image          = "nginx"
   container_name = var.container_name
   restart_policy = "always"
+  environment    = var.environment
   docker_networks = {
     (var.network_name) = {
       ipam_config = {

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -5,3 +5,7 @@ output "volumes" {
 output "devices" {
   value = module.docker.devices
 }
+
+output "environment" {
+  value = module.docker.environment
+}

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -19,21 +19,26 @@ variable "subnet" {
 }
 
 variable "ports" {
-  type    = list
+  type    = list(any)
   default = null
 }
 
 variable "named_volumes" {
-  type    = map
+  type    = map(any)
   default = {}
 }
 
 variable "host_paths" {
-  type    = map
+  type    = map(any)
   default = {}
 }
 
 variable "devices" {
-  type    = map
+  type    = map(any)
   default = {}
+}
+
+variable "environment" {
+  type    = map(string)
+  default = null
 }

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "docker_container" "default" {
   working_dir  = var.working_dir
   dns          = var.dns
   command      = var.command
-  env          = var.environment
+  env          = var.environment != null ? [for k, v in var.environment : "${k}=${v}"] : null
 
   dynamic "ports" {
     for_each = var.ports == null ? [] : var.ports

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,7 @@ output "volumes" {
 output "devices" {
   value = docker_container.default.devices
 }
+
+output "environment" {
+  value = docker_container.default.env
+}

--- a/variables.tf
+++ b/variables.tf
@@ -112,7 +112,7 @@ variable "healthcheck" {
 }
 variable "environment" {
   description = "Add environment variables"
-  type        = list(string)
+  type        = map(string)
   default     = null
 }
 variable "docker_networks" {


### PR DESCRIPTION
Instead of declaring docker environments as list of strings
```
environment = [
  "MYKEY1=MYVALUE1",
  "MYKEY2=MYVALUE2"
]
```

We should declare it as a map
```
environment = {
  MYKEY1 = "MYVALUE1"
  MYKEY2 = "MYVALUE2"
}
```