### PR TITLE
refactor: upgrade requirements for terraform and docker provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     docker = {
       source  = "kreuzwerker/docker"
-      version = "~> 2.7"
+      version = "~> 3.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = "~> 1.4"
 }


### PR DESCRIPTION
It should work with up to date docker provider version & terraform version. 
This PR upgrade those requirements.