### PR TITLE
fix: conditionally create volumes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,8 +14,11 @@ resource "docker_image" "default" {
 }
 
 resource "docker_volume" "default" {
-  for_each = var.named_volumes
-  name     = each.key
+  for_each = {
+    for k, v in var.named_volumes : k => v
+    if lookup(v, "create", false) != false
+  }
+  name = each.key
 }
 
 resource "docker_network" "default" {


### PR DESCRIPTION
A new volume should be created only if the `create` attribute is set to true. This is useful when the volume is created by another module.