### PR TITLE
revert: "fix: allow multiple networks to same container (#57)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ No modules.
 | <a name="input_image"></a> [image](#input\_image) | Specify the image to start the container from. Can either be a repository/tag or a partial image ID | `string` | n/a | yes |
 | <a name="input_named_volumes"></a> [named\_volumes](#input\_named\_volumes) | Mount named volumes | <pre>map(object({<br>    container_path = string<br>    read_only      = bool<br>    create         = bool<br>  }))</pre> | `{}` | no |
 | <a name="input_network_mode"></a> [network\_mode](#input\_network\_mode) | Specify a custom network mode | `string` | `null` | no |
-| <a name="input_networks_advanced"></a> [networks\_advanced](#input\_networks\_advanced) | Advanced network options for the container<pre>networks_advanced = [<br>  {<br>    name         = "proxy-tier"<br>    ipv4_address = "10.0.0.14"<br>  },<br>  {<br>    name         = "media-tier"<br>    ipv4_address = "172.0.0.14"<br>  }<br>]</pre> | `any` | `null` | no |
+| <a name="input_networks_advanced"></a> [networks\_advanced](#input\_networks\_advanced) | Advanced network options for the container | <pre>object({<br>    name         = string<br>    aliases      = list(string)<br>    ipv4_address = string<br>    ipv6_address = string<br>  })</pre> | `null` | no |
 | <a name="input_ports"></a> [ports](#input\_ports) | Expose ports | <pre>list(object({<br>    internal = number<br>    external = number<br>    protocol = string<br>  }))</pre> | `null` | no |
 | <a name="input_privileged"></a> [privileged](#input\_privileged) | Give extended privileges to this container | `bool` | `false` | no |
 | <a name="input_restart_policy"></a> [restart\_policy](#input\_restart\_policy) | Restart policy. Default: no | `string` | `"no"` | no |

--- a/main.tf
+++ b/main.tf
@@ -2,11 +2,6 @@ locals {
   image          = var.image
   img_nouser     = replace(local.image, "/", "") != local.image ? split("/", local.image)[1] : split("/", local.image)[0]
   container_name = split(":", local.img_nouser)[0]
-  networks_advanced = try(
-    element(var.networks_advanced, 0),
-    var.networks_advanced
-  )
-  networks_advanced_list = tolist([local.networks_advanced])
 }
 
 data "docker_registry_image" "default" {
@@ -103,12 +98,12 @@ resource "docker_container" "default" {
   }
 
   dynamic "networks_advanced" {
-    for_each = local.networks_advanced_list == null ? [] : local.networks_advanced_list
+    for_each = var.networks_advanced == null ? [] : [var.networks_advanced]
     content {
-      name         = lookup(networks_advanced.value, "name", null)
-      ipv4_address = lookup(networks_advanced.value, "ipv4_address", null)
-      ipv6_address = lookup(networks_advanced.value, "ipv6_address", null)
-      aliases      = lookup(networks_advanced.value, "aliases", null)
+      name         = var.networks_advanced.name
+      ipv4_address = var.networks_advanced.ipv4_address
+      ipv6_address = var.networks_advanced.ipv6_address
+      aliases      = var.networks_advanced.aliases
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -95,23 +95,14 @@ variable "capabilities" {
   default = null
 }
 variable "networks_advanced" {
-  description = <<EOD
-Advanced network options for the container
-```
-networks_advanced = [
-  {
-    name         = "proxy-tier"
-    ipv4_address = "10.0.0.14"
-  },
-  {
-    name         = "media-tier"
-    ipv4_address = "172.0.0.14"
-  }
-]
-```
-EOD
-  type        = any
-  default     = null
+  description = "Advanced network options for the container"
+  type = object({
+    name         = string
+    aliases      = list(string)
+    ipv4_address = string
+    ipv6_address = string
+  })
+  default = null
 }
 variable "healthcheck" {
   description = "Test to check if container is healthy"


### PR DESCRIPTION
This reverts commit 67f50225a8d226a5da55a2f4a179d656b84ca367.

As this is a breaking change, it should be commited as a feature, not as a fix.