### PR TITLE
feat: allow multiple networks for same container

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ No modules.
 | <a name="input_container_name"></a> [container\_name](#input\_container\_name) | Custom container name | `string` | `null` | no |
 | <a name="input_devices"></a> [devices](#input\_devices) | Device mappings | <pre>map(object({<br>    container_path = string<br>    permissions    = string<br>  }))</pre> | `{}` | no |
 | <a name="input_dns"></a> [dns](#input\_dns) | Set custom dns servers for the container | `list(string)` | `null` | no |
-| <a name="input_docker_networks"></a> [docker\_networks](#input\_docker\_networks) | List of custom networks to create | <pre>map(object({<br>    ipam_config = object({<br>      aux_address = map(string)<br>      gateway     = string<br>      subnet      = string<br>    })<br>  }))</pre> | `{}` | no |
+| <a name="input_docker_networks"></a> [docker\_networks](#input\_docker\_networks) | List of custom networks to create<pre>hcl<br>docker_networks = [<br>  {<br>    name = "proxy-tier"<br>    ipam_config = {<br>      aux_address = {}<br>      gateway     = "10.0.0.1"<br>      subnet      = "10.0.0.0/24"<br>    }<br>  }<br>]</pre> | `any` | `null` | no |
 | <a name="input_entrypoint"></a> [entrypoint](#input\_entrypoint) | Override the default entrypoint | `list(string)` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Add environment variables | `map(string)` | `null` | no |
 | <a name="input_healthcheck"></a> [healthcheck](#input\_healthcheck) | Test to check if container is healthy | <pre>object({<br>    interval     = string<br>    retries      = number<br>    start_period = string<br>    test         = list(string)<br>    timeout      = string<br>  })</pre> | `null` | no |
@@ -157,7 +157,7 @@ No modules.
 | <a name="input_image"></a> [image](#input\_image) | Specify the image to start the container from. Can either be a repository/tag or a partial image ID | `string` | n/a | yes |
 | <a name="input_named_volumes"></a> [named\_volumes](#input\_named\_volumes) | Mount named volumes | <pre>map(object({<br>    container_path = string<br>    read_only      = bool<br>    create         = bool<br>  }))</pre> | `{}` | no |
 | <a name="input_network_mode"></a> [network\_mode](#input\_network\_mode) | Specify a custom network mode | `string` | `null` | no |
-| <a name="input_networks_advanced"></a> [networks\_advanced](#input\_networks\_advanced) | Advanced network options for the container<pre>networks_advanced = [<br>  {<br>    name         = "proxy-tier"<br>    ipv4_address = "10.0.0.14"<br>  },<br>  {<br>    name         = "media-tier"<br>    ipv4_address = "172.0.0.14"<br>  }<br>]</pre> | `any` | `null` | no |
+| <a name="input_networks_advanced"></a> [networks\_advanced](#input\_networks\_advanced) | Advanced network options for the container<pre>hcl<br>networks_advanced = [<br>  {<br>    name         = "proxy-tier"<br>    ipv4_address = "10.0.0.14"<br>  },<br>  {<br>    name         = "media-tier"<br>    ipv4_address = "172.0.0.14"<br>  }<br>]</pre> | `any` | `null` | no |
 | <a name="input_ports"></a> [ports](#input\_ports) | Expose ports | <pre>list(object({<br>    internal = number<br>    external = number<br>    protocol = string<br>  }))</pre> | `null` | no |
 | <a name="input_privileged"></a> [privileged](#input\_privileged) | Give extended privileges to this container | `bool` | `false` | no |
 | <a name="input_restart_policy"></a> [restart\_policy](#input\_restart\_policy) | Restart policy. Default: no | `string` | `"no"` | no |

--- a/README.md
+++ b/README.md
@@ -168,7 +168,23 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_capabilities"></a> [capabilities](#output\_capabilities) | n/a |
+| <a name="output_command"></a> [command](#output\_command) | n/a |
+| <a name="output_container_name"></a> [container\_name](#output\_container\_name) | n/a |
 | <a name="output_devices"></a> [devices](#output\_devices) | n/a |
+| <a name="output_dns"></a> [dns](#output\_dns) | n/a |
+| <a name="output_docker_networks"></a> [docker\_networks](#output\_docker\_networks) | n/a |
+| <a name="output_docker_volumes"></a> [docker\_volumes](#output\_docker\_volumes) | n/a |
+| <a name="output_entrypoint"></a> [entrypoint](#output\_entrypoint) | n/a |
 | <a name="output_environment"></a> [environment](#output\_environment) | n/a |
+| <a name="output_healthcheck"></a> [healthcheck](#output\_healthcheck) | n/a |
+| <a name="output_hostname"></a> [hostname](#output\_hostname) | n/a |
+| <a name="output_image"></a> [image](#output\_image) | n/a |
+| <a name="output_network_mode"></a> [network\_mode](#output\_network\_mode) | n/a |
+| <a name="output_networks_advanced"></a> [networks\_advanced](#output\_networks\_advanced) | n/a |
+| <a name="output_ports"></a> [ports](#output\_ports) | n/a |
+| <a name="output_privileged"></a> [privileged](#output\_privileged) | n/a |
+| <a name="output_restart"></a> [restart](#output\_restart) | n/a |
 | <a name="output_volumes"></a> [volumes](#output\_volumes) | n/a |
+| <a name="output_working_dir"></a> [working\_dir](#output\_working\_dir) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ No modules.
 | <a name="input_image"></a> [image](#input\_image) | Specify the image to start the container from. Can either be a repository/tag or a partial image ID | `string` | n/a | yes |
 | <a name="input_named_volumes"></a> [named\_volumes](#input\_named\_volumes) | Mount named volumes | <pre>map(object({<br>    container_path = string<br>    read_only      = bool<br>    create         = bool<br>  }))</pre> | `{}` | no |
 | <a name="input_network_mode"></a> [network\_mode](#input\_network\_mode) | Specify a custom network mode | `string` | `null` | no |
-| <a name="input_networks_advanced"></a> [networks\_advanced](#input\_networks\_advanced) | Advanced network options for the container | <pre>object({<br>    name         = string<br>    aliases      = list(string)<br>    ipv4_address = string<br>    ipv6_address = string<br>  })</pre> | `null` | no |
+| <a name="input_networks_advanced"></a> [networks\_advanced](#input\_networks\_advanced) | Advanced network options for the container<pre>networks_advanced = [<br>  {<br>    name         = "proxy-tier"<br>    ipv4_address = "10.0.0.14"<br>  },<br>  {<br>    name         = "media-tier"<br>    ipv4_address = "172.0.0.14"<br>  }<br>]</pre> | `any` | `null` | no |
 | <a name="input_ports"></a> [ports](#input\_ports) | Expose ports | <pre>list(object({<br>    internal = number<br>    external = number<br>    protocol = string<br>  }))</pre> | `null` | no |
 | <a name="input_privileged"></a> [privileged](#input\_privileged) | Give extended privileges to this container | `bool` | `false` | no |
 | <a name="input_restart_policy"></a> [restart\_policy](#input\_restart\_policy) | Restart policy. Default: no | `string` | `"no"` | no |

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -23,7 +23,7 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_container_name"></a> [container\_name](#input\_container\_name) | n/a | `string` | n/a | yes |
 | <a name="input_devices"></a> [devices](#input\_devices) | n/a | `map(any)` | `{}` | no |
-| <a name="input_docker_networks"></a> [docker\_networks](#input\_docker\_networks) | n/a | `map(any)` | `{}` | no |
+| <a name="input_docker_networks"></a> [docker\_networks](#input\_docker\_networks) | n/a | `list(any)` | `[]` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | n/a | `map(string)` | `null` | no |
 | <a name="input_host_paths"></a> [host\_paths](#input\_host\_paths) | n/a | `map(any)` | `{}` | no |
 | <a name="input_named_volumes"></a> [named\_volumes](#input\_named\_volumes) | n/a | `map(any)` | `{}` | no |

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -21,20 +21,46 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_capabilities"></a> [capabilities](#input\_capabilities) | n/a | `map(any)` | `{}` | no |
+| <a name="input_command"></a> [command](#input\_command) | n/a | `list(string)` | `null` | no |
 | <a name="input_container_name"></a> [container\_name](#input\_container\_name) | n/a | `string` | n/a | yes |
 | <a name="input_devices"></a> [devices](#input\_devices) | n/a | `map(any)` | `{}` | no |
+| <a name="input_dns"></a> [dns](#input\_dns) | n/a | `list(string)` | `null` | no |
 | <a name="input_docker_networks"></a> [docker\_networks](#input\_docker\_networks) | n/a | `list(any)` | `[]` | no |
+| <a name="input_entrypoint"></a> [entrypoint](#input\_entrypoint) | n/a | `list(string)` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | n/a | `map(string)` | `null` | no |
 | <a name="input_host_paths"></a> [host\_paths](#input\_host\_paths) | n/a | `map(any)` | `{}` | no |
+| <a name="input_hostname"></a> [hostname](#input\_hostname) | n/a | `string` | `null` | no |
+| <a name="input_image"></a> [image](#input\_image) | n/a | `string` | n/a | yes |
 | <a name="input_named_volumes"></a> [named\_volumes](#input\_named\_volumes) | n/a | `map(any)` | `{}` | no |
+| <a name="input_network_mode"></a> [network\_mode](#input\_network\_mode) | n/a | `string` | `null` | no |
 | <a name="input_networks_advanced"></a> [networks\_advanced](#input\_networks\_advanced) | n/a | `list(any)` | `[]` | no |
 | <a name="input_ports"></a> [ports](#input\_ports) | n/a | `list(any)` | `null` | no |
+| <a name="input_privileged"></a> [privileged](#input\_privileged) | n/a | `bool` | `false` | no |
+| <a name="input_restart_policy"></a> [restart\_policy](#input\_restart\_policy) | n/a | `string` | `null` | no |
+| <a name="input_working_dir"></a> [working\_dir](#input\_working\_dir) | n/a | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| <a name="output_capabilities"></a> [capabilities](#output\_capabilities) | n/a |
+| <a name="output_command"></a> [command](#output\_command) | n/a |
+| <a name="output_container_name"></a> [container\_name](#output\_container\_name) | n/a |
 | <a name="output_devices"></a> [devices](#output\_devices) | n/a |
+| <a name="output_dns"></a> [dns](#output\_dns) | n/a |
+| <a name="output_docker_networks"></a> [docker\_networks](#output\_docker\_networks) | n/a |
+| <a name="output_docker_volumes"></a> [docker\_volumes](#output\_docker\_volumes) | n/a |
+| <a name="output_entrypoint"></a> [entrypoint](#output\_entrypoint) | n/a |
 | <a name="output_environment"></a> [environment](#output\_environment) | n/a |
+| <a name="output_healthcheck"></a> [healthcheck](#output\_healthcheck) | n/a |
+| <a name="output_hostname"></a> [hostname](#output\_hostname) | n/a |
+| <a name="output_image"></a> [image](#output\_image) | n/a |
+| <a name="output_network_mode"></a> [network\_mode](#output\_network\_mode) | n/a |
+| <a name="output_networks_advanced"></a> [networks\_advanced](#output\_networks\_advanced) | n/a |
+| <a name="output_ports"></a> [ports](#output\_ports) | n/a |
+| <a name="output_privileged"></a> [privileged](#output\_privileged) | n/a |
+| <a name="output_restart"></a> [restart](#output\_restart) | n/a |
 | <a name="output_volumes"></a> [volumes](#output\_volumes) | n/a |
+| <a name="output_working_dir"></a> [working\_dir](#output\_working\_dir) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -23,14 +23,12 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_container_name"></a> [container\_name](#input\_container\_name) | n/a | `string` | n/a | yes |
 | <a name="input_devices"></a> [devices](#input\_devices) | n/a | `map(any)` | `{}` | no |
+| <a name="input_docker_networks"></a> [docker\_networks](#input\_docker\_networks) | n/a | `map(any)` | `{}` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | n/a | `map(string)` | `null` | no |
-| <a name="input_gateway"></a> [gateway](#input\_gateway) | n/a | `string` | n/a | yes |
 | <a name="input_host_paths"></a> [host\_paths](#input\_host\_paths) | n/a | `map(any)` | `{}` | no |
-| <a name="input_ipv4_address"></a> [ipv4\_address](#input\_ipv4\_address) | n/a | `string` | n/a | yes |
 | <a name="input_named_volumes"></a> [named\_volumes](#input\_named\_volumes) | n/a | `map(any)` | `{}` | no |
-| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | n/a | `string` | n/a | yes |
+| <a name="input_networks_advanced"></a> [networks\_advanced](#input\_networks\_advanced) | n/a | `list(any)` | `[]` | no |
 | <a name="input_ports"></a> [ports](#input\_ports) | n/a | `list(any)` | `null` | no |
-| <a name="input_subnet"></a> [subnet](#input\_subnet) | n/a | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,9 +1,17 @@
 module "docker" {
   source = "../.."
 
-  image             = "nginx"
+  image             = var.image
   container_name    = var.container_name
-  restart_policy    = "always"
+  hostname          = var.hostname
+  restart_policy    = var.restart_policy
+  working_dir       = var.working_dir
+  privileged        = var.privileged
+  network_mode      = var.network_mode
+  dns               = var.dns
+  entrypoint        = var.entrypoint
+  command           = var.command
+  capabilities      = var.capabilities
   environment       = var.environment
   docker_networks   = var.docker_networks
   ports             = var.ports

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,27 +1,14 @@
 module "docker" {
   source = "../.."
 
-  image          = "nginx"
-  container_name = var.container_name
-  restart_policy = "always"
-  environment    = var.environment
-  docker_networks = {
-    (var.network_name) = {
-      ipam_config = {
-        aux_address = {}
-        gateway     = var.gateway
-        subnet      = var.subnet
-      }
-    }
-  }
-  ports         = var.ports
-  named_volumes = var.named_volumes
-  host_paths    = var.host_paths
-  devices       = var.devices
-  networks_advanced = {
-    name         = var.network_name
-    ipv4_address = var.ipv4_address
-    ipv6_address = null
-    aliases      = null
-  }
+  image             = "nginx"
+  container_name    = var.container_name
+  restart_policy    = "always"
+  environment       = var.environment
+  docker_networks   = var.docker_networks
+  ports             = var.ports
+  named_volumes     = var.named_volumes
+  host_paths        = var.host_paths
+  devices           = var.devices
+  networks_advanced = var.networks_advanced
 }

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -1,11 +1,75 @@
+output "image" {
+  value = module.docker.image
+}
+
+output "container_name" {
+  value = module.docker.container_name
+}
+
+output "hostname" {
+  value = module.docker.hostname
+}
+
+output "working_dir" {
+  value = module.docker.working_dir
+}
+
+output "restart" {
+  value = module.docker.restart
+}
+
+output "privileged" {
+  value = module.docker.privileged
+}
+
+output "network_mode" {
+  value = module.docker.network_mode
+}
+
+output "dns" {
+  value = module.docker.dns
+}
+
+output "entrypoint" {
+  value = module.docker.entrypoint
+}
+
+output "command" {
+  value = module.docker.command
+}
+
+output "ports" {
+  value = module.docker.ports
+}
+
 output "volumes" {
   value = module.docker.volumes
+}
+
+output "docker_volumes" {
+  value = module.docker.docker_volumes
 }
 
 output "devices" {
   value = module.docker.devices
 }
 
+output "capabilities" {
+  value = module.docker.capabilities
+}
+
+output "networks_advanced" {
+  value = module.docker.networks_advanced
+}
+
+output "healthcheck" {
+  value = module.docker.healthcheck
+}
+
 output "environment" {
   value = module.docker.environment
+}
+
+output "docker_networks" {
+  value = module.docker.docker_networks
 }

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -1,5 +1,49 @@
+variable "image" {
+  type = string
+}
+
 variable "container_name" {
   type = string
+}
+
+variable "hostname" {
+  type    = string
+  default = null
+}
+
+variable "restart_policy" {
+  type    = string
+  default = null
+}
+
+variable "working_dir" {
+  type    = string
+  default = null
+}
+
+variable "privileged" {
+  type    = bool
+  default = false
+}
+
+variable "network_mode" {
+  type    = string
+  default = null
+}
+
+variable "dns" {
+  type    = list(string)
+  default = null
+}
+
+variable "entrypoint" {
+  type    = list(string)
+  default = null
+}
+
+variable "command" {
+  type    = list(string)
+  default = null
 }
 
 variable "ports" {
@@ -18,6 +62,11 @@ variable "host_paths" {
 }
 
 variable "devices" {
+  type    = map(any)
+  default = {}
+}
+
+variable "capabilities" {
   type    = map(any)
   default = {}
 }

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -33,6 +33,6 @@ variable "networks_advanced" {
 }
 
 variable "docker_networks" {
-  type    = map(any)
-  default = {}
+  type    = list(any)
+  default = []
 }

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -2,22 +2,6 @@ variable "container_name" {
   type = string
 }
 
-variable "network_name" {
-  type = string
-}
-
-variable "gateway" {
-  type = string
-}
-
-variable "ipv4_address" {
-  type = string
-}
-
-variable "subnet" {
-  type = string
-}
-
 variable "ports" {
   type    = list(any)
   default = null
@@ -41,4 +25,14 @@ variable "devices" {
 variable "environment" {
   type    = map(string)
   default = null
+}
+
+variable "networks_advanced" {
+  type    = list(any)
+  default = []
+}
+
+variable "docker_networks" {
+  type    = map(any)
+  default = {}
 }

--- a/main.tf
+++ b/main.tf
@@ -98,12 +98,12 @@ resource "docker_container" "default" {
   }
 
   dynamic "networks_advanced" {
-    for_each = var.networks_advanced == null ? [] : [var.networks_advanced]
+    for_each = var.networks_advanced == null ? [] : var.networks_advanced
     content {
-      name         = var.networks_advanced.name
-      ipv4_address = var.networks_advanced.ipv4_address
-      ipv6_address = var.networks_advanced.ipv6_address
-      aliases      = var.networks_advanced.aliases
+      name         = lookup(networks_advanced.value, "name", null)
+      ipv4_address = lookup(networks_advanced.value, "ipv4_address", null)
+      ipv6_address = lookup(networks_advanced.value, "ipv6_address", null)
+      aliases      = lookup(networks_advanced.value, "aliases", null)
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -22,16 +22,17 @@ resource "docker_volume" "default" {
 }
 
 resource "docker_network" "default" {
-  for_each = var.docker_networks
-  name     = each.key
+  for_each = {
+    for i, v in var.docker_networks : v.name => v
+  }
+  name = each.value.name
 
   ipam_config {
-    aux_address = each.value.ipam_config.aux_address
-    gateway     = each.value.ipam_config.gateway
-    subnet      = each.value.ipam_config.subnet
+    aux_address = lookup(each.value.ipam_config, "aux_address", null)
+    gateway     = lookup(each.value.ipam_config, "gateway", null)
+    subnet      = lookup(each.value.ipam_config, "subnet", null)
   }
 }
-
 
 resource "docker_container" "default" {
   name         = var.container_name != null ? var.container_name : local.container_name

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,73 @@
+output "image" {
+  value = docker_image.default.name
+}
+
+output "container_name" {
+  value = docker_container.default.name
+}
+
+output "hostname" {
+  value = docker_container.default.hostname
+}
+
+output "working_dir" {
+  value = docker_container.default.working_dir
+}
+
+output "restart" {
+  value = docker_container.default.restart
+}
+
+output "privileged" {
+  value = docker_container.default.privileged
+}
+
+output "network_mode" {
+  value = docker_container.default.network_mode
+}
+
+output "dns" {
+  value = docker_container.default.dns
+}
+
+output "entrypoint" {
+  value = docker_container.default.entrypoint
+}
+
+output "command" {
+  value = docker_container.default.command
+}
+
+output "ports" {
+  value = docker_container.default.ports
+}
+
 output "volumes" {
   value = docker_container.default.volumes
 }
 
+output "docker_volumes" {
+  value = docker_volume.default
+}
+
 output "devices" {
   value = docker_container.default.devices
+}
+
+output "capabilities" {
+  value = docker_container.default.capabilities
+}
+
+output "networks_advanced" {
+  value = docker_container.default.networks_advanced
+}
+
+output "docker_networks" {
+  value = docker_network.default
+}
+
+output "healthcheck" {
+  value = docker_container.default.healthcheck
 }
 
 output "environment" {

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -12,8 +12,9 @@ func TestTerraformDockerSimple(t *testing.T) {
   containerName := "single_port"
 
 
-  dockerNetworks := map[string]interface{}{
-    "nginx_network": map[string]interface{}{
+  dockerNetworks := []map[string]interface{}{
+    {
+      "name": "nginx_network",
       "ipam_config": map[string]interface{}{
         "aux_address": map[string]interface{}{},
         "gateway": "10.0.30.1",
@@ -122,8 +123,9 @@ func TestTerraformDockerSimple(t *testing.T) {
 
 func TestTerraformDockerMultiple(t *testing.T) {
   containerName := "multiple_ports"
-  dockerNetworks := map[string]interface{}{
-    "nginx_network": map[string]interface{}{
+  dockerNetworks := []map[string]interface{}{
+    {
+      "name": "nginx_network",
       "ipam_config": map[string]interface{}{
         "aux_address": map[string]interface{}{},
         "gateway": "10.0.30.1",
@@ -274,8 +276,9 @@ func TestTerraformDockerMultiple(t *testing.T) {
 
 func TestTerraformDockerWithoutPortsVolumesDevices(t *testing.T) {
   containerName := "without"
-  dockerNetworks := map[string]interface{}{
-    "nginx_network": map[string]interface{}{
+  dockerNetworks := []map[string]interface{}{
+    {
+      "name": "nginx_network",
       "ipam_config": map[string]interface{}{
         "aux_address": map[string]interface{}{},
         "gateway": "10.0.30.1",
@@ -327,8 +330,9 @@ func TestTerraformDockerWithoutPortsVolumesDevices(t *testing.T) {
 
 func TestTerraformDockerEnvironments(t *testing.T) {
   containerName := "environments"
-  dockerNetworks := map[string]interface{}{
-    "nginx_network": map[string]interface{}{
+  dockerNetworks := []map[string]interface{}{
+    {
+      "name": "nginx_network",
       "ipam_config": map[string]interface{}{
         "aux_address": map[string]interface{}{},
         "gateway": "10.0.30.1",

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -1,327 +1,373 @@
 package test
 
 import (
-	"testing"
+  "testing"
 
-	"github.com/gruntwork-io/terratest/modules/docker"
-	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/stretchr/testify/assert"
+  "github.com/gruntwork-io/terratest/modules/docker"
+  "github.com/gruntwork-io/terratest/modules/terraform"
+  "github.com/stretchr/testify/assert"
 )
 
 func TestTerraformDockerSimple(t *testing.T) {
-	containerName := "single_port"
-	gateway := "10.0.30.1"
-	ipv4Address := "10.0.30.2"
-	subnet := "10.0.30.0/24"
-	networkName := "nginx_network"
+  containerName := "single_port"
 
-	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: "../examples/basic",
 
-		Vars: map[string]interface{}{
-			"container_name": containerName,
-			"gateway":        gateway,
-			"ipv4_address":   ipv4Address,
-			"subnet":         subnet,
-			"network_name":   networkName,
-			"ports": []map[string]interface{}{
-				{
-					"internal": 80,
-					"external": 80,
-					"protocol": "tcp",
-				},
-			},
-			"named_volumes": map[string]interface{}{
-				"nginx_config": map[string]interface{}{
-					"container_path": "/etc/nginx",
-					"read_only":      false,
-					"create":         true,
-				},
-			},
-			"host_paths": map[string]interface{}{
-				"/media/local": map[string]interface{}{
-					"container_path": "/mnt",
-					"read_only":      true,
-				},
-			},
-			"devices": map[string]interface{}{
-				"/dev/null": map[string]interface{}{
-					"container_path": "/dev/null",
-					"permissions":    "rwm",
-				},
-			},
-		},
+  dockerNetworks := map[string]interface{}{
+    "nginx_network": map[string]interface{}{
+      "ipam_config": map[string]interface{}{
+        "aux_address": map[string]interface{}{},
+        "gateway": "10.0.30.1",
+        "subnet": "10.0.30.0/24",
+      },
+    },
+  }
+  networksAdvanced := []map[string]interface{}{
+    {
+      "name": "nginx_network",
+      "ipv4_address": "10.0.30.2",
+    },
+  }
+  ports := []map[string]interface{}{
+    {
+      "internal": 80,
+      "external": 80,
+      "protocol": "tcp",
+    },
+  }
+  namedVolumes := map[string]interface{}{
+    "nginx_config": map[string]interface{}{
+      "container_path": "/etc/nginx",
+      "read_only":      false,
+      "create":         true,
+    },
+  }
+  hostPaths := map[string]interface{}{
+    "/media/local": map[string]interface{}{
+      "container_path": "/mnt",
+      "read_only":      true,
+    },
+  }
+  devices := map[string]interface{}{
+    "/dev/null": map[string]interface{}{
+      "container_path": "/dev/null",
+      "permissions":    "rwm",
+    },
+  }
 
-		NoColor: true,
-	})
+  terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+    TerraformDir: "../examples/basic",
 
-	defer terraform.Destroy(t, terraformOptions)
+    Vars: map[string]interface{}{
+      "container_name": containerName,
+      "docker_networks": dockerNetworks,
+      "networks_advanced": networksAdvanced,
+      "ports": ports,
+      "named_volumes": namedVolumes,
+      "host_paths": hostPaths,
+      "devices": devices,
+    },
 
-	terraform.InitAndApply(t, terraformOptions)
+    NoColor: true,
+  })
 
-	inspectOutput := docker.Inspect(
-		t,
-		containerName,
-	)
+  defer terraform.Destroy(t, terraformOptions)
 
-	expectedPorts := []docker.Port{
-		{
-			HostPort:      80,
-			ContainerPort: 80,
-			Protocol:      "tcp",
-		},
-	}
-	actualPorts := inspectOutput.Ports
+  terraform.InitAndApply(t, terraformOptions)
 
-	expectedVolumes := []map[string]interface{}{
-		{
-			"container_path": "/etc/nginx",
-			"from_container": "",
-			"host_path":      "",
-			"read_only":      false,
-			"volume_name":    "nginx_config",
-		},
-		{
-			"container_path": "/mnt",
-			"from_container": "",
-			"host_path":      "/media/local",
-			"read_only":      true,
-			"volume_name":    "",
-		},
-	}
-	actualVolumes := terraform.OutputListOfObjects(t, terraformOptions, "volumes")
+  inspectOutput := docker.Inspect(
+    t,
+    containerName,
+  )
 
-	expectedDevices := []map[string]interface{}{
-		{
-			"container_path": "/dev/null",
-			"host_path":      "/dev/null",
-			"permissions":    "rwm",
-		},
-	}
-	actualDevices := terraform.OutputListOfObjects(t, terraformOptions, "devices")
+  expectedPorts := []docker.Port{
+    {
+      HostPort:      80,
+      ContainerPort: 80,
+      Protocol:      "tcp",
+    },
+  }
+  actualPorts := inspectOutput.Ports
 
-	assert.Equal(t, expectedPorts, actualPorts)
-	assert.Equal(t, expectedVolumes, actualVolumes)
-	assert.Equal(t, expectedDevices, actualDevices)
+  expectedVolumes := []map[string]interface{}{
+    {
+      "container_path": "/etc/nginx",
+      "from_container": "",
+      "host_path":      "",
+      "read_only":      false,
+      "volume_name":    "nginx_config",
+    },
+    {
+      "container_path": "/mnt",
+      "from_container": "",
+      "host_path":      "/media/local",
+      "read_only":      true,
+      "volume_name":    "",
+    },
+  }
+  actualVolumes := terraform.OutputListOfObjects(t, terraformOptions, "volumes")
+
+  expectedDevices := []map[string]interface{}{
+    {
+      "container_path": "/dev/null",
+      "host_path":      "/dev/null",
+      "permissions":    "rwm",
+    },
+  }
+  actualDevices := terraform.OutputListOfObjects(t, terraformOptions, "devices")
+
+  assert.Equal(t, expectedPorts, actualPorts)
+  assert.Equal(t, expectedVolumes, actualVolumes)
+  assert.Equal(t, expectedDevices, actualDevices)
 }
 
 func TestTerraformDockerMultiple(t *testing.T) {
-	containerName := "multiple_ports"
-	gateway := "10.0.30.1"
-	ipv4Address := "10.0.30.2"
-	subnet := "10.0.30.0/24"
-	networkName := "nginx_network"
+  containerName := "multiple_ports"
+  dockerNetworks := map[string]interface{}{
+    "nginx_network": map[string]interface{}{
+      "ipam_config": map[string]interface{}{
+        "aux_address": map[string]interface{}{},
+        "gateway": "10.0.30.1",
+        "subnet": "10.0.30.0/24",
+      },
+    },
+  }
+  networksAdvanced := []map[string]interface{}{
+    {
+      "name": "nginx_network",
+      "ipv4_address": "10.0.30.2",
+    },
+  }
+  ports := []map[string]interface{}{
+    {
+      "internal": 80,
+      "external": 80,
+      "protocol": "tcp",
+    },
+    {
+      "internal": 443,
+      "external": 443,
+      "protocol": "tcp",
+    },
+  }
+  namedVolumes := map[string]interface{}{
+    "nginx_config": map[string]interface{}{
+      "container_path": "/etc/nginx",
+      "read_only":      false,
+      "create":         true,
+    },
+    "nginx_html": map[string]interface{}{
+      "container_path": "/var/www/html",
+      "read_only":      false,
+      "create":         true,
+    },
+  }
+  hostPaths := map[string]interface{}{
+    "/media/local": map[string]interface{}{
+      "container_path": "/mnt",
+      "read_only":      true,
+    },
+    "/opt/test": map[string]interface{}{
+      "container_path": "/opt/test",
+      "read_only":      false,
+    },
+  }
+  devices := map[string]interface{}{
+    "/dev/null": map[string]interface{}{
+      "container_path": "/dev/null",
+      "permissions":    "rwm",
+    },
+    "/dev/random": map[string]interface{}{
+      "container_path": "/dev/random",
+      "permissions":    "rwm",
+    },
+  }
 
-	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: "../examples/basic",
+  terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+    TerraformDir: "../examples/basic",
 
-		Vars: map[string]interface{}{
-			"container_name": containerName,
-			"gateway":        gateway,
-			"ipv4_address":   ipv4Address,
-			"subnet":         subnet,
-			"network_name":   networkName,
-			"ports": []map[string]interface{}{
-				{
-					"internal": 80,
-					"external": 80,
-					"protocol": "tcp",
-				},
-				{
-					"internal": 443,
-					"external": 443,
-					"protocol": "tcp",
-				},
-			},
-			"named_volumes": map[string]interface{}{
-				"nginx_config": map[string]interface{}{
-					"container_path": "/etc/nginx",
-					"read_only":      false,
-					"create":         true,
-				},
-				"nginx_html": map[string]interface{}{
-					"container_path": "/var/www/html",
-					"read_only":      false,
-					"create":         true,
-				},
-			},
-			"host_paths": map[string]interface{}{
-				"/media/local": map[string]interface{}{
-					"container_path": "/mnt",
-					"read_only":      true,
-				},
-				"/opt/test": map[string]interface{}{
-					"container_path": "/opt/test",
-					"read_only":      false,
-				},
-			},
-			"devices": map[string]interface{}{
-				"/dev/null": map[string]interface{}{
-					"container_path": "/dev/null",
-					"permissions":    "rwm",
-				},
-				"/dev/random": map[string]interface{}{
-					"container_path": "/dev/random",
-					"permissions":    "rwm",
-				},
-			},
-		},
+    Vars: map[string]interface{}{
+      "container_name": containerName,
+      "docker_networks": dockerNetworks,
+      "networks_advanced": networksAdvanced,
+      "ports": ports,
+      "named_volumes": namedVolumes,
+      "host_paths": hostPaths,
+      "devices": devices,
+    },
 
-		NoColor: true,
-	})
+    NoColor: true,
+  })
 
-	defer terraform.Destroy(t, terraformOptions)
+  defer terraform.Destroy(t, terraformOptions)
 
-	terraform.InitAndApply(t, terraformOptions)
+  terraform.InitAndApply(t, terraformOptions)
 
-	output := docker.Inspect(
-		t,
-		containerName,
-	)
+  output := docker.Inspect(
+    t,
+    containerName,
+  )
 
-	expectedPorts := []docker.Port{
-		{
-			HostPort:      443,
-			ContainerPort: 443,
-			Protocol:      "tcp",
-		},
-		{
-			HostPort:      80,
-			ContainerPort: 80,
-			Protocol:      "tcp",
-		},
-	}
-	actualPorts := output.Ports
+  expectedPorts := []docker.Port{
+    {
+      HostPort:      443,
+      ContainerPort: 443,
+      Protocol:      "tcp",
+    },
+    {
+      HostPort:      80,
+      ContainerPort: 80,
+      Protocol:      "tcp",
+    },
+  }
+  actualPorts := output.Ports
 
-	expectedVolumes := []map[string]interface{}{
-		{
-			"container_path": "/etc/nginx",
-			"from_container": "",
-			"host_path":      "",
-			"read_only":      false,
-			"volume_name":    "nginx_config",
-		},
-		{
-			"container_path": "/mnt",
-			"from_container": "",
-			"host_path":      "/media/local",
-			"read_only":      true,
-			"volume_name":    "",
-		},
-		{
-			"container_path": "/opt/test",
-			"from_container": "",
-			"host_path":      "/opt/test",
-			"read_only":      false,
-			"volume_name":    "",
-		},
-		{
-			"container_path": "/var/www/html",
-			"from_container": "",
-			"host_path":      "",
-			"read_only":      false,
-			"volume_name":    "nginx_html",
-		},
-	}
-	actualVolumes := terraform.OutputListOfObjects(t, terraformOptions, "volumes")
+  expectedVolumes := []map[string]interface{}{
+    {
+      "container_path": "/etc/nginx",
+      "from_container": "",
+      "host_path":      "",
+      "read_only":      false,
+      "volume_name":    "nginx_config",
+    },
+    {
+      "container_path": "/mnt",
+      "from_container": "",
+      "host_path":      "/media/local",
+      "read_only":      true,
+      "volume_name":    "",
+    },
+    {
+      "container_path": "/opt/test",
+      "from_container": "",
+      "host_path":      "/opt/test",
+      "read_only":      false,
+      "volume_name":    "",
+    },
+    {
+      "container_path": "/var/www/html",
+      "from_container": "",
+      "host_path":      "",
+      "read_only":      false,
+      "volume_name":    "nginx_html",
+    },
+  }
+  actualVolumes := terraform.OutputListOfObjects(t, terraformOptions, "volumes")
 
-	expectedDevices := []map[string]interface{}{
-		{
-			"container_path": "/dev/null",
-			"host_path":      "/dev/null",
-			"permissions":    "rwm",
-		},
-		{
-			"container_path": "/dev/random",
-			"host_path":      "/dev/random",
-			"permissions":    "rwm",
-		},
-	}
-	actualDevices := terraform.OutputListOfObjects(t, terraformOptions, "devices")
+  expectedDevices := []map[string]interface{}{
+    {
+      "container_path": "/dev/null",
+      "host_path":      "/dev/null",
+      "permissions":    "rwm",
+    },
+    {
+      "container_path": "/dev/random",
+      "host_path":      "/dev/random",
+      "permissions":    "rwm",
+    },
+  }
+  actualDevices := terraform.OutputListOfObjects(t, terraformOptions, "devices")
 
-	assert.Equal(t, expectedPorts, actualPorts)
-	assert.Equal(t, expectedVolumes, actualVolumes)
-	assert.Equal(t, expectedDevices, actualDevices)
+  assert.Equal(t, expectedPorts, actualPorts)
+  assert.Equal(t, expectedVolumes, actualVolumes)
+  assert.Equal(t, expectedDevices, actualDevices)
 }
 
 func TestTerraformDockerWithoutPortsVolumesDevices(t *testing.T) {
-	containerName := "without"
-	gateway := "10.0.30.1"
-	ipv4Address := "10.0.30.2"
-	subnet := "10.0.30.0/24"
-	networkName := "nginx_network"
+  containerName := "without"
+  dockerNetworks := map[string]interface{}{
+    "nginx_network": map[string]interface{}{
+      "ipam_config": map[string]interface{}{
+        "aux_address": map[string]interface{}{},
+        "gateway": "10.0.30.1",
+        "subnet": "10.0.30.0/24",
+      },
+    },
+  }
+  networksAdvanced := []map[string]interface{}{
+    {
+      "name": "nginx_network",
+      "ipv4_address": "10.0.30.2",
+    },
+  }
 
-	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: "../examples/basic",
+  terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+    TerraformDir: "../examples/basic",
 
-		Vars: map[string]interface{}{
-			"container_name": containerName,
-			"gateway":        gateway,
-			"ipv4_address":   ipv4Address,
-			"subnet":         subnet,
-			"network_name":   networkName,
-		},
+    Vars: map[string]interface{}{
+      "container_name": containerName,
+      "docker_networks": dockerNetworks,
+      "networks_advanced": networksAdvanced,
+    },
 
-		NoColor: true,
-	})
+    NoColor: true,
+  })
 
-	defer terraform.Destroy(t, terraformOptions)
+  defer terraform.Destroy(t, terraformOptions)
 
-	terraform.InitAndApply(t, terraformOptions)
+  terraform.InitAndApply(t, terraformOptions)
 
-	inspectOutput := docker.Inspect(
-		t,
-		containerName,
-	)
+  inspectOutput := docker.Inspect(
+    t,
+    containerName,
+  )
 
-	expectedPorts := []docker.Port(nil)
-	actualPorts := inspectOutput.Ports
+  expectedPorts := []docker.Port(nil)
+  actualPorts := inspectOutput.Ports
 
-	expectedVolumes := []map[string]interface{}(nil)
-	actualVolumes := terraform.OutputListOfObjects(t, terraformOptions, "volumes")
+  expectedVolumes := []map[string]interface{}(nil)
+  actualVolumes := terraform.OutputListOfObjects(t, terraformOptions, "volumes")
 
-	expectedDevices := []map[string]interface{}(nil)
-	actualDevices := terraform.OutputListOfObjects(t, terraformOptions, "devices")
+  expectedDevices := []map[string]interface{}(nil)
+  actualDevices := terraform.OutputListOfObjects(t, terraformOptions, "devices")
 
-	assert.Equal(t, expectedPorts, actualPorts)
-	assert.Equal(t, expectedVolumes, actualVolumes)
-	assert.Equal(t, expectedDevices, actualDevices)
+  assert.Equal(t, expectedPorts, actualPorts)
+  assert.Equal(t, expectedVolumes, actualVolumes)
+  assert.Equal(t, expectedDevices, actualDevices)
 }
 
 func TestTerraformDockerEnvironments(t *testing.T) {
-	containerName := "environments"
-	gateway := "10.0.30.1"
-	ipv4Address := "10.0.30.2"
-	subnet := "10.0.30.0/24"
-	networkName := "nginx_network"
-	environment := map[string]interface{}{
-		"ENV":  "test",
-		"NAME": "nginx",
-	}
+  containerName := "environments"
+  dockerNetworks := map[string]interface{}{
+    "nginx_network": map[string]interface{}{
+      "ipam_config": map[string]interface{}{
+        "aux_address": map[string]interface{}{},
+        "gateway": "10.0.30.1",
+        "subnet": "10.0.30.0/24",
+      },
+    },
+  }
+  networksAdvanced := []map[string]interface{}{
+    {
+      "name": "nginx_network",
+      "ipv4_address": "10.0.30.2",
+    },
+  }
+  environment := map[string]interface{}{
+    "ENV":  "test",
+    "NAME": "nginx",
+  }
 
-	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: "../examples/basic",
+  terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+    TerraformDir: "../examples/basic",
 
-		Vars: map[string]interface{}{
-			"container_name": containerName,
-			"gateway":        gateway,
-			"ipv4_address":   ipv4Address,
-			"subnet":         subnet,
-			"network_name":   networkName,
-			"environment":    environment,
-		},
+    Vars: map[string]interface{}{
+      "container_name": containerName,
+      "docker_networks": dockerNetworks,
+      "networks_advanced": networksAdvanced,
+      "environment":    environment,
+    },
 
-		NoColor: true,
-	})
+    NoColor: true,
+  })
 
-	defer terraform.Destroy(t, terraformOptions)
+  defer terraform.Destroy(t, terraformOptions)
 
-	terraform.InitAndApply(t, terraformOptions)
+  terraform.InitAndApply(t, terraformOptions)
 
-	expectedEnv := []string{
-		"ENV=test",
-		"NAME=nginx",
-	}
-	actualEnv := terraform.OutputList(t, terraformOptions, "environment")
-	assert.Equal(t, expectedEnv, actualEnv)
+  expectedEnv := []string{
+    "ENV=test",
+    "NAME=nginx",
+  }
+  actualEnv := terraform.OutputList(t, terraformOptions, "environment")
+  assert.Equal(t, expectedEnv, actualEnv)
 }

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -1,377 +1,261 @@
 package test
 
 import (
-  "testing"
+	"testing"
 
-  "github.com/gruntwork-io/terratest/modules/docker"
-  "github.com/gruntwork-io/terratest/modules/terraform"
-  "github.com/stretchr/testify/assert"
+	"github.com/Jeffail/gabs"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestTerraformDockerSimple(t *testing.T) {
-  containerName := "single_port"
-
-
-  dockerNetworks := []map[string]interface{}{
-    {
-      "name": "nginx_network",
-      "ipam_config": map[string]interface{}{
-        "aux_address": map[string]interface{}{},
-        "gateway": "10.0.30.1",
-        "subnet": "10.0.30.0/24",
-      },
-    },
-  }
-  networksAdvanced := []map[string]interface{}{
-    {
-      "name": "nginx_network",
-      "ipv4_address": "10.0.30.2",
-    },
-  }
-  ports := []map[string]interface{}{
-    {
-      "internal": 80,
-      "external": 80,
-      "protocol": "tcp",
-    },
-  }
-  namedVolumes := map[string]interface{}{
-    "nginx_config": map[string]interface{}{
-      "container_path": "/etc/nginx",
-      "read_only":      false,
-      "create":         true,
-    },
-  }
-  hostPaths := map[string]interface{}{
-    "/media/local": map[string]interface{}{
-      "container_path": "/mnt",
-      "read_only":      true,
-    },
-  }
-  devices := map[string]interface{}{
-    "/dev/null": map[string]interface{}{
-      "container_path": "/dev/null",
-      "permissions":    "rwm",
-    },
-  }
-
-  terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-    TerraformDir: "../examples/basic",
-
-    Vars: map[string]interface{}{
-      "container_name": containerName,
-      "docker_networks": dockerNetworks,
-      "networks_advanced": networksAdvanced,
-      "ports": ports,
-      "named_volumes": namedVolumes,
-      "host_paths": hostPaths,
-      "devices": devices,
-    },
-
-    NoColor: true,
-  })
-
-  defer terraform.Destroy(t, terraformOptions)
-
-  terraform.InitAndApply(t, terraformOptions)
-
-  inspectOutput := docker.Inspect(
-    t,
-    containerName,
-  )
-
-  expectedPorts := []docker.Port{
-    {
-      HostPort:      80,
-      ContainerPort: 80,
-      Protocol:      "tcp",
-    },
-  }
-  actualPorts := inspectOutput.Ports
-
-  expectedVolumes := []map[string]interface{}{
-    {
-      "container_path": "/etc/nginx",
-      "from_container": "",
-      "host_path":      "",
-      "read_only":      false,
-      "volume_name":    "nginx_config",
-    },
-    {
-      "container_path": "/mnt",
-      "from_container": "",
-      "host_path":      "/media/local",
-      "read_only":      true,
-      "volume_name":    "",
-    },
-  }
-  actualVolumes := terraform.OutputListOfObjects(t, terraformOptions, "volumes")
-
-  expectedDevices := []map[string]interface{}{
-    {
-      "container_path": "/dev/null",
-      "host_path":      "/dev/null",
-      "permissions":    "rwm",
-    },
-  }
-  actualDevices := terraform.OutputListOfObjects(t, terraformOptions, "devices")
-
-  assert.Equal(t, expectedPorts, actualPorts)
-  assert.Equal(t, expectedVolumes, actualVolumes)
-  assert.Equal(t, expectedDevices, actualDevices)
-}
-
-func TestTerraformDockerMultiple(t *testing.T) {
-  containerName := "multiple_ports"
-  dockerNetworks := []map[string]interface{}{
-    {
-      "name": "nginx_network",
-      "ipam_config": map[string]interface{}{
-        "aux_address": map[string]interface{}{},
-        "gateway": "10.0.30.1",
-        "subnet": "10.0.30.0/24",
-      },
-    },
-  }
-  networksAdvanced := []map[string]interface{}{
-    {
-      "name": "nginx_network",
-      "ipv4_address": "10.0.30.2",
-    },
-  }
-  ports := []map[string]interface{}{
-    {
-      "internal": 80,
-      "external": 80,
-      "protocol": "tcp",
-    },
-    {
-      "internal": 443,
-      "external": 443,
-      "protocol": "tcp",
-    },
-  }
-  namedVolumes := map[string]interface{}{
-    "nginx_config": map[string]interface{}{
-      "container_path": "/etc/nginx",
-      "read_only":      false,
-      "create":         true,
-    },
-    "nginx_html": map[string]interface{}{
-      "container_path": "/var/www/html",
-      "read_only":      false,
-      "create":         true,
-    },
-  }
-  hostPaths := map[string]interface{}{
-    "/media/local": map[string]interface{}{
-      "container_path": "/mnt",
-      "read_only":      true,
-    },
-    "/opt/test": map[string]interface{}{
-      "container_path": "/opt/test",
-      "read_only":      false,
-    },
-  }
-  devices := map[string]interface{}{
-    "/dev/null": map[string]interface{}{
-      "container_path": "/dev/null",
-      "permissions":    "rwm",
-    },
-    "/dev/random": map[string]interface{}{
-      "container_path": "/dev/random",
-      "permissions":    "rwm",
-    },
-  }
-
-  terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-    TerraformDir: "../examples/basic",
-
-    Vars: map[string]interface{}{
-      "container_name": containerName,
-      "docker_networks": dockerNetworks,
-      "networks_advanced": networksAdvanced,
-      "ports": ports,
-      "named_volumes": namedVolumes,
-      "host_paths": hostPaths,
-      "devices": devices,
-    },
-
-    NoColor: true,
-  })
-
-  defer terraform.Destroy(t, terraformOptions)
-
-  terraform.InitAndApply(t, terraformOptions)
-
-  output := docker.Inspect(
-    t,
-    containerName,
-  )
-
-  expectedPorts := []docker.Port{
-    {
-      HostPort:      443,
-      ContainerPort: 443,
-      Protocol:      "tcp",
-    },
-    {
-      HostPort:      80,
-      ContainerPort: 80,
-      Protocol:      "tcp",
-    },
-  }
-  actualPorts := output.Ports
-
-  expectedVolumes := []map[string]interface{}{
-    {
-      "container_path": "/etc/nginx",
-      "from_container": "",
-      "host_path":      "",
-      "read_only":      false,
-      "volume_name":    "nginx_config",
-    },
-    {
-      "container_path": "/mnt",
-      "from_container": "",
-      "host_path":      "/media/local",
-      "read_only":      true,
-      "volume_name":    "",
-    },
-    {
-      "container_path": "/opt/test",
-      "from_container": "",
-      "host_path":      "/opt/test",
-      "read_only":      false,
-      "volume_name":    "",
-    },
-    {
-      "container_path": "/var/www/html",
-      "from_container": "",
-      "host_path":      "",
-      "read_only":      false,
-      "volume_name":    "nginx_html",
-    },
-  }
-  actualVolumes := terraform.OutputListOfObjects(t, terraformOptions, "volumes")
-
-  expectedDevices := []map[string]interface{}{
-    {
-      "container_path": "/dev/null",
-      "host_path":      "/dev/null",
-      "permissions":    "rwm",
-    },
-    {
-      "container_path": "/dev/random",
-      "host_path":      "/dev/random",
-      "permissions":    "rwm",
-    },
-  }
-  actualDevices := terraform.OutputListOfObjects(t, terraformOptions, "devices")
-
-  assert.Equal(t, expectedPorts, actualPorts)
-  assert.Equal(t, expectedVolumes, actualVolumes)
-  assert.Equal(t, expectedDevices, actualDevices)
-}
-
-func TestTerraformDockerWithoutPortsVolumesDevices(t *testing.T) {
-  containerName := "without"
-  dockerNetworks := []map[string]interface{}{
-    {
-      "name": "nginx_network",
-      "ipam_config": map[string]interface{}{
-        "aux_address": map[string]interface{}{},
-        "gateway": "10.0.30.1",
-        "subnet": "10.0.30.0/24",
-      },
-    },
-  }
-  networksAdvanced := []map[string]interface{}{
-    {
-      "name": "nginx_network",
-      "ipv4_address": "10.0.30.2",
-    },
-  }
-
-  terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-    TerraformDir: "../examples/basic",
-
-    Vars: map[string]interface{}{
-      "container_name": containerName,
-      "docker_networks": dockerNetworks,
-      "networks_advanced": networksAdvanced,
-    },
-
-    NoColor: true,
-  })
-
-  defer terraform.Destroy(t, terraformOptions)
-
-  terraform.InitAndApply(t, terraformOptions)
-
-  inspectOutput := docker.Inspect(
-    t,
-    containerName,
-  )
-
-  expectedPorts := []docker.Port(nil)
-  actualPorts := inspectOutput.Ports
-
-  expectedVolumes := []map[string]interface{}(nil)
-  actualVolumes := terraform.OutputListOfObjects(t, terraformOptions, "volumes")
-
-  expectedDevices := []map[string]interface{}(nil)
-  actualDevices := terraform.OutputListOfObjects(t, terraformOptions, "devices")
-
-  assert.Equal(t, expectedPorts, actualPorts)
-  assert.Equal(t, expectedVolumes, actualVolumes)
-  assert.Equal(t, expectedDevices, actualDevices)
-}
-
 func TestTerraformDockerEnvironments(t *testing.T) {
-  containerName := "environments"
-  dockerNetworks := []map[string]interface{}{
-    {
-      "name": "nginx_network",
-      "ipam_config": map[string]interface{}{
-        "aux_address": map[string]interface{}{},
-        "gateway": "10.0.30.1",
-        "subnet": "10.0.30.0/24",
-      },
-    },
-  }
-  networksAdvanced := []map[string]interface{}{
-    {
-      "name": "nginx_network",
-      "ipv4_address": "10.0.30.2",
-    },
-  }
-  environment := map[string]interface{}{
-    "ENV":  "test",
-    "NAME": "nginx",
-  }
+	image := "nginx:latest"
+	containerName := "terraform-test"
+	hostname := "terratest"
+	workingDir := "/tmp"
+	restart_policy := "unless-stopped"
+	privileged := false
+	network_mode := "bridge"
+	dns := []string{"1.1.1.1", "1.0.0.1"}
+	entrypoint := []string{"/docker-entrypoint.sh"}
+	command := []string{"nginx", "-g", "daemon off;"}
+	ports := []map[string]interface{}{
+		{
+			"internal": 80,
+			"external": 9999,
+			"protocol": "tcp",
+		},
+	}
+	named_volumes := map[string]interface{}{
+		"nginx_volume": map[string]interface{}{
+			"container_path": "/etc/nginx",
+			"read_only":      false,
+			"create":         true,
+		},
+		"mnt_volume": map[string]interface{}{
+			"container_path": "/mnt",
+			"read_only":      false,
+			"create":         true,
+		},
+	}
+	host_paths := map[string]interface{}{
+		"/tmp": map[string]interface{}{
+			"container_path": "/tmp",
+			"read_only":      true,
+		},
+	}
+	devices := map[string]interface{}{
+		"/dev/null": map[string]interface{}{
+			"container_path": "/dev/newnull",
+			"permissions":    "rwm",
+		},
+	}
+	capabilities := map[string]interface{}{
+		"add":  []string{"NET_ADMIN"},
+		"drop": []string{},
+	}
+	dockerNetworks := []map[string]interface{}{
+		{
+			"name": "nginx_network",
+			"ipam_config": map[string]interface{}{
+				"aux_address": map[string]interface{}{},
+				"gateway":     "10.0.30.1",
+				"subnet":      "10.0.30.0/24",
+			},
+		},
+		{
+			"name": "app_network",
+			"ipam_config": map[string]interface{}{
+				"aux_address": map[string]interface{}{},
+				"gateway":     "10.0.55.1",
+				"subnet":      "10.0.55.0/24",
+			},
+		},
+	}
+	networksAdvanced := []map[string]interface{}{
+		{
+			"name":         "nginx_network",
+			"ipv4_address": "10.0.30.2",
+		},
+		{
+			"name":         "app_network",
+			"ipv4_address": "10.0.55.2",
+		},
+	}
+	environment := map[string]interface{}{
+		"ENV":  "test",
+		"NAME": "nginx",
+	}
 
-  terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-    TerraformDir: "../examples/basic",
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/basic",
 
-    Vars: map[string]interface{}{
-      "container_name": containerName,
-      "docker_networks": dockerNetworks,
-      "networks_advanced": networksAdvanced,
-      "environment":    environment,
-    },
+		Vars: map[string]interface{}{
+			"image":             image,
+			"container_name":    containerName,
+			"hostname":          hostname,
+			"working_dir":       workingDir,
+			"restart_policy":    restart_policy,
+			"privileged":        privileged,
+			"network_mode":      network_mode,
+			"dns":               dns,
+			"entrypoint":        entrypoint,
+			"command":           command,
+			"ports":             ports,
+			"named_volumes":     named_volumes,
+			"host_paths":        host_paths,
+			"devices":           devices,
+			"capabilities":      capabilities,
+			"docker_networks":   dockerNetworks,
+			"networks_advanced": networksAdvanced,
+			"environment":       environment,
+		},
 
-    NoColor: true,
-  })
+		NoColor: true,
+	})
 
-  defer terraform.Destroy(t, terraformOptions)
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+	validateOutputs(t, terraformOptions)
+}
 
-  terraform.InitAndApply(t, terraformOptions)
+func validateOutputs(t *testing.T, opts *terraform.Options) {
+	jsonParsed, err := gabs.ParseJSON([]byte(terraform.OutputJson(t, opts, "")))
+	if err != nil {
+		panic(err)
+	}
 
-  expectedEnv := []string{
-    "ENV=test",
-    "NAME=nginx",
-  }
-  actualEnv := terraform.OutputList(t, terraformOptions, "environment")
-  assert.Equal(t, expectedEnv, actualEnv)
+	// Image
+	image, _ := jsonParsed.JSONPointer("/image/value")
+	assert.Equal(t, "nginx:latest", image.Data().(string))
+
+	// Container name
+	container_name, _ := jsonParsed.JSONPointer("/container_name/value")
+	assert.Equal(t, "terraform-test", container_name.Data().(string))
+
+	// Hostname
+	hostname, _ := jsonParsed.JSONPointer("/hostname/value")
+	assert.Equal(t, "terratest", hostname.Data().(string))
+
+	// Working Dir
+	working_dir, _ := jsonParsed.JSONPointer("/working_dir/value")
+	assert.Equal(t, "/tmp", working_dir.Data().(string))
+
+	// Restart policy
+	restart_policy, _ := jsonParsed.JSONPointer("/restart/value")
+	assert.Equal(t, "unless-stopped", restart_policy.Data().(string))
+
+	// Privileged
+	privileged, _ := jsonParsed.JSONPointer("/privileged/value")
+	assert.Equal(t, false, privileged.Data().(bool))
+
+	// Network mode
+	network_mode, _ := jsonParsed.JSONPointer("/network_mode/value")
+	assert.Equal(t, "bridge", network_mode.Data().(string))
+
+	// DNS
+	dns1, _ := jsonParsed.JSONPointer("/dns/value/0")
+	assert.Equal(t, "1.0.0.1", dns1.Data().(string))
+
+	dns2, _ := jsonParsed.JSONPointer("/dns/value/1")
+	assert.Equal(t, "1.1.1.1", dns2.Data().(string))
+
+	// Entrypoint
+	entrypoint, _ := jsonParsed.JSONPointer("/entrypoint/value/0")
+	assert.Equal(t, "/docker-entrypoint.sh", entrypoint.Data().(string))
+
+	// Command
+	command1, _ := jsonParsed.JSONPointer("/command/value/0")
+	assert.Equal(t, "nginx", command1.Data().(string))
+
+	command2, _ := jsonParsed.JSONPointer("/command/value/1")
+	assert.Equal(t, "-g", command2.Data().(string))
+
+	command3, _ := jsonParsed.JSONPointer("/command/value/2")
+	assert.Equal(t, "daemon off;", command3.Data().(string))
+
+	// Ports
+	ports_internal, _ := jsonParsed.JSONPointer("/ports/value/0/internal")
+	assert.Equal(t, float64(80), ports_internal.Data().(float64))
+
+	ports_external, _ := jsonParsed.JSONPointer("/ports/value/0/external")
+	assert.Equal(t, float64(9999), ports_external.Data().(float64))
+
+	ports_protocol, _ := jsonParsed.JSONPointer("/ports/value/0/protocol")
+	assert.Equal(t, "tcp", ports_protocol.Data().(string))
+
+	// Named volumes
+	named_volumes1_name, _ := jsonParsed.JSONPointer("/volumes/value/0/volume_name")
+	assert.Equal(t, "nginx_volume", named_volumes1_name.Data().(string))
+
+	named_volumes1_container_path, _ := jsonParsed.JSONPointer("/volumes/value/0/container_path")
+	assert.Equal(t, "/etc/nginx", named_volumes1_container_path.Data().(string))
+
+	named_volumes1_host_path, _ := jsonParsed.JSONPointer("/volumes/value/0/host_path")
+	assert.Equal(t, "", named_volumes1_host_path.Data().(string))
+
+	docker_volumes1_name, _ := jsonParsed.JSONPointer("/docker_volumes/value")
+	assert.Equal(t, true, docker_volumes1_name.Exists("nginx_volume"))
+
+	named_volumes2_name, _ := jsonParsed.JSONPointer("/volumes/value/1/volume_name")
+	assert.Equal(t, "mnt_volume", named_volumes2_name.Data().(string))
+
+	named_volumes2_container_path, _ := jsonParsed.JSONPointer("/volumes/value/1/container_path")
+	assert.Equal(t, "/mnt", named_volumes2_container_path.Data().(string))
+
+	named_volumes2_host_path, _ := jsonParsed.JSONPointer("/volumes/value/1/host_path")
+	assert.Equal(t, "", named_volumes2_host_path.Data().(string))
+
+	docker_volumes2_name, _ := jsonParsed.JSONPointer("/docker_volumes/value")
+	assert.Equal(t, true, docker_volumes2_name.Exists("mnt_volume"))
+
+	// Host paths
+	host_paths_container_path, _ := jsonParsed.JSONPointer("/volumes/value/2/container_path")
+	assert.Equal(t, "/tmp", host_paths_container_path.Data().(string))
+
+	host_paths_volume_name, _ := jsonParsed.JSONPointer("/volumes/value/2/volume_name")
+	assert.Equal(t, "", host_paths_volume_name.Data().(string))
+
+	// Devices
+	devices_host_path, _ := jsonParsed.JSONPointer("/devices/value/0/host_path")
+	assert.Equal(t, "/dev/null", devices_host_path.Data().(string))
+
+	devices_container_path, _ := jsonParsed.JSONPointer("/devices/value/0/container_path")
+	assert.Equal(t, "/dev/newnull", devices_container_path.Data().(string))
+
+	// Capabilities
+	capabilities, _ := jsonParsed.JSONPointer("/capabilities/value/0/add/0")
+	assert.Equal(t, "NET_ADMIN", capabilities.Data().(string))
+
+	// Networks advanced
+	networks_advanced1_name, _ := jsonParsed.JSONPointer("/networks_advanced/value/0/name")
+	assert.Equal(t, "nginx_network", networks_advanced1_name.Data().(string))
+
+	networks_advanced1_ipv4_address, _ := jsonParsed.JSONPointer("/networks_advanced/value/0/ipv4_address")
+	assert.Equal(t, "10.0.30.2", networks_advanced1_ipv4_address.Data().(string))
+
+	networks_advanced2_name, _ := jsonParsed.JSONPointer("/networks_advanced/value/1/name")
+	assert.Equal(t, "app_network", networks_advanced2_name.Data().(string))
+
+	networks_advanced2_ipv4_address, _ := jsonParsed.JSONPointer("/networks_advanced/value/1/ipv4_address")
+	assert.Equal(t, "10.0.55.2", networks_advanced2_ipv4_address.Data().(string))
+
+	// Docker networks
+	docker_networks1_name, _ := jsonParsed.JSONPointer("/docker_networks/value")
+	assert.Equal(t, true, docker_networks1_name.Exists("nginx_network"))
+
+	docker_networks1_gateway, _ := jsonParsed.JSONPointer("/docker_networks/value/nginx_network/ipam_config/0/gateway")
+	assert.Equal(t, "10.0.30.1", docker_networks1_gateway.Data().(string))
+
+	docker_networks2_name, _ := jsonParsed.JSONPointer("/docker_networks/value")
+	assert.Equal(t, true, docker_networks2_name.Exists("app_network"))
+
+	docker_networks2_gateway, _ := jsonParsed.JSONPointer("/docker_networks/value/app_network/ipam_config/0/gateway")
+	assert.Equal(t, "10.0.55.1", docker_networks2_gateway.Data().(string))
+
+	// Environment Validation
+	environment_env, _ := jsonParsed.JSONPointer("/environment/value/0")
+	environment_name, _ := jsonParsed.JSONPointer("/environment/value/1")
+	assert.Equal(t, "ENV=test", environment_env.Data().(string))
+	assert.Equal(t, "NAME=nginx", environment_name.Data().(string))
 }

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -3,6 +3,7 @@ module github.com/alinefr/terraform-docker-module
 go 1.15
 
 require (
+	github.com/Jeffail/gabs v1.4.0 // indirect
 	github.com/gruntwork-io/terratest v0.31.1
 	github.com/stretchr/testify v1.6.1
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -48,6 +48,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced34534/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
+github.com/Jeffail/gabs v1.4.0 h1://5fYRRTq1edjfIrQGvdkcd22pkYUrHZ5YC/H2GJVAo=
+github.com/Jeffail/gabs v1.4.0/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/variables.tf
+++ b/variables.tf
@@ -95,14 +95,23 @@ variable "capabilities" {
   default = null
 }
 variable "networks_advanced" {
-  description = "Advanced network options for the container"
-  type = object({
-    name         = string
-    aliases      = list(string)
-    ipv4_address = string
-    ipv6_address = string
-  })
-  default = null
+  description = <<EOD
+Advanced network options for the container
+```
+networks_advanced = [
+  {
+    name         = "proxy-tier"
+    ipv4_address = "10.0.0.14"
+  },
+  {
+    name         = "media-tier"
+    ipv4_address = "172.0.0.14"
+  }
+]
+```
+EOD
+  type        = any
+  default     = null
 }
 variable "healthcheck" {
   description = "Test to check if container is healthy"

--- a/variables.tf
+++ b/variables.tf
@@ -97,7 +97,7 @@ variable "capabilities" {
 variable "networks_advanced" {
   description = <<EOD
 Advanced network options for the container
-```
+```hcl
 networks_advanced = [
   {
     name         = "proxy-tier"
@@ -130,13 +130,21 @@ variable "environment" {
   default     = null
 }
 variable "docker_networks" {
-  description = "List of custom networks to create"
-  type = map(object({
-    ipam_config = object({
-      aux_address = map(string)
-      gateway     = string
-      subnet      = string
-    })
-  }))
-  default = {}
+  description = <<EOD
+List of custom networks to create
+```hcl
+docker_networks = [
+  {
+    name = "proxy-tier"
+    ipam_config = {
+      aux_address = {}
+      gateway     = "10.0.0.1"
+      subnet      = "10.0.0.0/24"
+    }
+  }
+]
+```
+EOD
+  type        = any
+  default     = null
 }


### PR DESCRIPTION
The variable networks_advanced is now a list of objects instead of a single object.