### PR TITLE
feat: allow existing image to be used from another module

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ No modules.
 | <a name="output_environment"></a> [environment](#output\_environment) | n/a |
 | <a name="output_healthcheck"></a> [healthcheck](#output\_healthcheck) | n/a |
 | <a name="output_hostname"></a> [hostname](#output\_hostname) | n/a |
-| <a name="output_image"></a> [image](#output\_image) | n/a |
+| <a name="output_image_id"></a> [image\_id](#output\_image\_id) | n/a |
+| <a name="output_image_name"></a> [image\_name](#output\_image\_name) | n/a |
 | <a name="output_network_mode"></a> [network\_mode](#output\_network\_mode) | n/a |
 | <a name="output_networks_advanced"></a> [networks\_advanced](#output\_networks\_advanced) | n/a |
 | <a name="output_ports"></a> [ports](#output\_ports) | n/a |

--- a/README.md
+++ b/README.md
@@ -151,10 +151,11 @@ No modules.
 | <a name="input_docker_networks"></a> [docker\_networks](#input\_docker\_networks) | List of custom networks to create<pre>hcl<br>docker_networks = [<br>  {<br>    name = "proxy-tier"<br>    ipam_config = {<br>      aux_address = {}<br>      gateway     = "10.0.0.1"<br>      subnet      = "10.0.0.0/24"<br>    }<br>  }<br>]</pre> | `any` | `[]` | no |
 | <a name="input_entrypoint"></a> [entrypoint](#input\_entrypoint) | Override the default entrypoint | `list(string)` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Add environment variables | `map(string)` | `null` | no |
+| <a name="input_existing_image"></a> [existing\_image](#input\_existing\_image) | Specify an existing image from another module | `string` | `null` | no |
 | <a name="input_healthcheck"></a> [healthcheck](#input\_healthcheck) | Test to check if container is healthy | <pre>object({<br>    interval     = string<br>    retries      = number<br>    start_period = string<br>    test         = list(string)<br>    timeout      = string<br>  })</pre> | `null` | no |
 | <a name="input_host_paths"></a> [host\_paths](#input\_host\_paths) | Mount host paths | <pre>map(object({<br>    container_path = string<br>    read_only      = bool<br>  }))</pre> | `{}` | no |
 | <a name="input_hostname"></a> [hostname](#input\_hostname) | Set docker hostname | `string` | `null` | no |
-| <a name="input_image"></a> [image](#input\_image) | Specify the image to start the container from. Can either be a repository/tag or a partial image ID | `string` | n/a | yes |
+| <a name="input_image"></a> [image](#input\_image) | Specify the image to start the container from. Can either be a repository/tag or a partial image ID | `string` | `null` | no |
 | <a name="input_named_volumes"></a> [named\_volumes](#input\_named\_volumes) | Mount named volumes | <pre>map(object({<br>    container_path = string<br>    read_only      = bool<br>    create         = bool<br>  }))</pre> | `{}` | no |
 | <a name="input_network_mode"></a> [network\_mode](#input\_network\_mode) | Specify a custom network mode | `string` | `null` | no |
 | <a name="input_networks_advanced"></a> [networks\_advanced](#input\_networks\_advanced) | Advanced network options for the container<pre>hcl<br>networks_advanced = [<br>  {<br>    name         = "proxy-tier"<br>    ipv4_address = "10.0.0.14"<br>  },<br>  {<br>    name         = "media-tier"<br>    ipv4_address = "172.0.0.14"<br>  }<br>]</pre> | `any` | `null` | no |

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -58,7 +58,7 @@ No resources.
 | <a name="output_environment"></a> [environment](#output\_environment) | n/a |
 | <a name="output_healthcheck"></a> [healthcheck](#output\_healthcheck) | n/a |
 | <a name="output_hostname"></a> [hostname](#output\_hostname) | n/a |
-| <a name="output_image"></a> [image](#output\_image) | n/a |
+| <a name="output_image_name"></a> [image\_name](#output\_image\_name) | n/a |
 | <a name="output_network_mode"></a> [network\_mode](#output\_network\_mode) | n/a |
 | <a name="output_networks_advanced"></a> [networks\_advanced](#output\_networks\_advanced) | n/a |
 | <a name="output_ports"></a> [ports](#output\_ports) | n/a |

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -29,10 +29,11 @@ No resources.
 | <a name="input_docker_networks"></a> [docker\_networks](#input\_docker\_networks) | List of custom networks to create<pre>hcl<br>docker_networks = [<br>  {<br>    name = "proxy-tier"<br>    ipam_config = {<br>      aux_address = {}<br>      gateway     = "10.0.0.1"<br>      subnet      = "10.0.0.0/24"<br>    }<br>  }<br>]</pre> | `any` | `[]` | no |
 | <a name="input_entrypoint"></a> [entrypoint](#input\_entrypoint) | Override the default entrypoint | `list(string)` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Add environment variables | `map(string)` | `null` | no |
+| <a name="input_existing_image"></a> [existing\_image](#input\_existing\_image) | Specify an existing image from another module | `string` | `null` | no |
 | <a name="input_healthcheck"></a> [healthcheck](#input\_healthcheck) | Test to check if container is healthy | <pre>object({<br>    interval     = string<br>    retries      = number<br>    start_period = string<br>    test         = list(string)<br>    timeout      = string<br>  })</pre> | `null` | no |
 | <a name="input_host_paths"></a> [host\_paths](#input\_host\_paths) | Mount host paths | <pre>map(object({<br>    container_path = string<br>    read_only      = bool<br>  }))</pre> | `{}` | no |
 | <a name="input_hostname"></a> [hostname](#input\_hostname) | Set docker hostname | `string` | `null` | no |
-| <a name="input_image"></a> [image](#input\_image) | Specify the image to start the container from. Can either be a repository/tag or a partial image ID | `string` | n/a | yes |
+| <a name="input_image"></a> [image](#input\_image) | Specify the image to start the container from. Can either be a repository/tag or a partial image ID | `string` | `null` | no |
 | <a name="input_named_volumes"></a> [named\_volumes](#input\_named\_volumes) | Mount named volumes | <pre>map(object({<br>    container_path = string<br>    read_only      = bool<br>    create         = bool<br>  }))</pre> | `{}` | no |
 | <a name="input_network_mode"></a> [network\_mode](#input\_network\_mode) | Specify a custom network mode | `string` | `null` | no |
 | <a name="input_networks_advanced"></a> [networks\_advanced](#input\_networks\_advanced) | Advanced network options for the container<pre>hcl<br>networks_advanced = [<br>  {<br>    name         = "proxy-tier"<br>    ipv4_address = "10.0.0.14"<br>  },<br>  {<br>    name         = "media-tier"<br>    ipv4_address = "172.0.0.14"<br>  }<br>]</pre> | `any` | `null` | no |

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -1,5 +1,5 @@
-output "image" {
-  value = module.docker.image
+output "image_name" {
+  value = module.docker.image_name
 }
 
 output "container_name" {

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -1,6 +1,12 @@
 variable "image" {
   description = "Specify the image to start the container from. Can either be a repository/tag or a partial image ID"
   type        = string
+  default     = null
+}
+variable "existing_image" {
+  description = "Specify an existing image from another module"
+  type        = string
+  default     = null
 }
 variable "container_name" {
   description = "Custom container name"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,8 @@
-output "image" {
+output "image_name" {
+  value = var.existing_image != null ? var.existing_image : docker_image.default[var.image].name
+}
+
+output "image_id" {
   value = var.existing_image != null ? var.existing_image : docker_image.default[var.image].image_id
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "image" {
-  value = docker_image.default.name
+  value = var.existing_image != null ? var.existing_image : docker_image.default[var.image].image_id
 }
 
 output "container_name" {

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -126,7 +126,7 @@ func validateOutputs(t *testing.T, opts *terraform.Options) {
 	}
 
 	// Image
-	image, _ := jsonParsed.JSONPointer("/image/value")
+	image, _ := jsonParsed.JSONPointer("/image_name/value")
 	assert.Equal(t, "nginx:latest", image.Data().(string))
 
 	// Container name

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,12 @@
 variable "image" {
   description = "Specify the image to start the container from. Can either be a repository/tag or a partial image ID"
   type        = string
+  default     = null
+}
+variable "existing_image" {
+  description = "Specify an existing image from another module"
+  type        = string
+  default     = null
 }
 variable "container_name" {
   description = "Custom container name"


### PR DESCRIPTION
This allow us to use more than one module for a single image.
My use case is nextcloud. Nextcloud has an app container. It's the `nextcloud:26-fpm-alpine`. 
There is another container with the same image, the cron container. Nextcloud uses this second container to execute jobs perodically. But, it's the same `nextcloud:26-fpm-alpine` image. 

This PR allow us to use an existing image from another module (which here it means, from another container).